### PR TITLE
Adds "Other" tab for demo aggregation

### DIFF
--- a/packages/web-demo/src/App.tsx
+++ b/packages/web-demo/src/App.tsx
@@ -7,6 +7,7 @@ import PageQrcode from './pages/qrcode';
 import PageRainbowKit from './pages/rainbowKit';
 import PageWeb3Modal from './pages/web3Modal';
 import PageWebRedirect from './pages/webRedirect';
+import PageOther from './pages/other';
 
 // TODO:set debug for internal test, developer must remove it.
 window.__PARTICLE_ENVIRONMENT__ = process.env.REACT_APP_PARTICLE_ENV;
@@ -21,6 +22,7 @@ function App() {
                 <Route path="/web3Modal" element={<PageWeb3Modal />} />
                 <Route path="/connectKit" element={<PageConnectKit />} />
                 <Route path="/qrcode" element={<PageQrcode />} />
+                <Route path="/other" element={<PageOther />} />
                 <Route path="/webRedirect" element={<PageWebRedirect />} />
                 <Route path="*" element={<Page404 />} />
             </Routes>

--- a/packages/web-demo/src/pages/index.tsx
+++ b/packages/web-demo/src/pages/index.tsx
@@ -380,6 +380,14 @@ function Home() {
             ),
             key: 'BrowserDemo',
         },
+        {
+            label: (
+                <a href="/other" target="_blank" rel="noopener noreferrer">
+                    Other
+                </a>
+            ),
+            key: 'Other',
+        },
     ];
 
     const ConnectButtonFC = () => {
@@ -490,6 +498,7 @@ function Home() {
             <p onClick={() => openWindow('/rainbowKit')}>RainbowKit</p>
             <p onClick={() => openWindow('/web3Modal')}>Web3Modal</p>
             <p onClick={() => openWindow('https://static.particle.network/sdks/web/index.html')}>BrowserDemo</p>
+            <p onClick={() => openWindow('/other')}>Other</p>
         </div>
     );
 

--- a/packages/web-demo/src/pages/other/index.scss
+++ b/packages/web-demo/src/pages/other/index.scss
@@ -1,0 +1,138 @@
+.page-container {
+    padding: 0;
+    background-color: #f6f6f6;
+    font-family: sans-serif;
+  }
+  
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start; 
+    padding: 10px 20px;
+    background-color: #ffffff;
+    width: 100%;
+  }
+  
+  .logo-img {
+    height: 50px;
+    width: auto;
+  }
+  
+  .demo-text {
+    font-size: 24px;
+    margin-left: 10px;
+    font-weight: bold;
+  }
+  
+  .grid-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 2rem;
+    padding: 2rem;
+  }
+  
+  .grid-item {
+    background-color: #f9f9f9;
+    border: 1px solid #ccc;
+    padding: 0;
+    border-radius: 8px;
+    position: relative;
+    margin: 1rem;
+    transition: transform 0.3s;
+    box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+  }
+  
+  .grid-item:hover {
+    transform: translateY(-10px);
+    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
+  }
+  
+  .thumbnail {
+    width: 100%;
+    padding-top: 50%;
+    background-size: cover;
+    background-position: center;
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+  }
+  
+  .demo-name {
+    font-weight: bold;
+    font-size: 1.5rem;
+    padding-left: 5%;
+  }
+  
+  .icon-container {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+  
+  .play-button {
+    background-color: rgba(0, 0, 0, 0.2);
+    border: none;
+    border-radius: 50%;
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+    position: relative;
+  }
+  
+  .play-button:before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 55%;
+    transform: translate(-50%, -50%);
+    width: 0;
+    height: 0;
+    border-top: 8px solid transparent;
+    border-bottom: 8px solid transparent;
+    border-left: 12px solid white;
+  }
+  
+  .play-button:hover {
+    background-color: rgba(0, 0, 0, 0.4);
+  }
+  
+  .play-button:focus {
+    outline: none;
+  }
+  
+  .github-icon {
+    width: 24px;
+    height: 24px;
+    margin-right: 5px;
+    cursor: pointer;
+    transition: opacity 0.2s;
+  }
+  
+  .github-icon:hover {
+    opacity: 0.8;
+  }
+  
+  .box {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+  
+  .content {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 100%;
+    height: 100%;
+  }
+  
+  .bottom-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+  
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+  

--- a/packages/web-demo/src/pages/other/index.tsx
+++ b/packages/web-demo/src/pages/other/index.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import './index.scss';
+
+const demos = [
+  {
+    name: 'Leveraging Smart WaaS with Pimlico',
+    thumbnail: 'https://i.imgur.com/3w04ByD.jpg',
+    thumbnailLink: 'https://particle-pimlico-demo.replit.app/',
+    playLink: 'https://twitter.com/TABASCOweb3/status/1717549871811469450',
+    githubLink: 'https://t.co/FWC4aphmE2',
+  },
+  {
+    name: 'Account Kit Utilization with Particle WaaS',
+    thumbnail: 'https://i.imgur.com/5pwg8vI.jpg',
+    thumbnailLink: 'https://particle-account-kit.replit.app/',
+    playLink: 'https://twitter.com/TABASCOweb3/status/1715034613184147721',
+    githubLink: 'https://github.com/TABASCOatw/particle-account-kit-demo',
+  },
+  {
+    name: 'Biconomy Paymasters with Particle WaaS',
+    thumbnail: 'https://i.imgur.com/dlHEeQO.png',
+    thumbnailLink: 'https://particle-account-kit.replit.app/',
+    playLink: 'https://twitter.com/ParticleNtwrk/status/1712423989296214252',
+    githubLink: 'https://github.com/TABASCOatw/particle-biconomy-example',
+  },
+  {
+    name: 'Phantom & Particle Connection with Particle Connect',
+    thumbnail: 'https://i.imgur.com/DcGjPTd.png',
+    thumbnailLink: 'https://solana-particle-connect.replit.app/',
+    playLink: 'https://twitter.com/TABASCOweb3/status/1715667302278918578',
+    githubLink: 'https://github.com/TABASCOatw/particle-connect-boilerplate/blob/main/src/App-Solana.tsx',
+  },
+  {
+    name: 'WaaS-enabled Avalanche DApp',
+    thumbnail: 'https://i.imgur.com/6Eyisxj.png',
+    thumbnailLink: 'https://particle-auth-avalanche-example.replit.app/',
+    playLink: 'https://twitter.com/TABASCOweb3/status/1710546274435621330',
+    githubLink: 'https://github.com/TABASCOatw/particle-auth-avalanche-example',
+  },
+  {
+    name: 'Social Login with wallet-adapter & Particle Auth',
+    thumbnail: 'https://i.imgur.com/NQlw1OT.png',
+    thumbnailLink: 'https://particle-google-solana-demo.replit.app/',
+    playLink: 'https://twitter.com/TABASCOweb3/status/1709900102494777414',
+    githubLink: 'https://github.com/TABASCOatw/particle-solana-google-example',
+  },
+  {
+    name: 'Gasless Transactions & Session Keys with Openfort',
+    thumbnail: 'https://i.imgur.com/WcNFEfH.png',
+    thumbnailLink: 'https://particle-openfort-demo.replit.app/',
+    playLink: 'https://twitter.com/TABASCOweb3/status/1713146824511684855',
+    githubLink: 'https://github.com/TABASCOatw/particle-openfort-demo',
+  },
+  {
+    name: 'Using Particle WaaS with ZeroDev',
+    thumbnail: 'https://i.imgur.com/244tUjY.png',
+    thumbnailLink: 'https://particle-zerodev-demo.replit.app/',
+    playLink: 'https://twitter.com/TABASCOweb3/status/1718184402969059421',
+    githubLink: 'https://github.com/TABASCOatw/particle-zerodev-demo',
+  },
+  {
+    name: 'Leveraging Smart WaaS on Fantom',
+    thumbnail: 'https://i.imgur.com/VF3FMmh.png',
+    thumbnailLink: 'https://particle-fantom-demo.replit.app/',
+    playLink: 'https://twitter.com/TABASCOweb3/status/1727513542830526875',
+    githubLink: 'https://github.com/TABASCOatw/particle-fantom-demo',
+  },
+];
+
+const PageOther: React.FC = () => {
+  return (
+    <div className="page-container">
+      <div className="header">
+        <img src="https://i.imgur.com/R0Rv19y.png" alt="Particle Network Logo" className="logo-img" />
+        <span className="demo-text">Particle Demo</span>
+      </div>
+      <div className="grid-container">
+        {demos.map((demo, index) => (
+          <div className="grid-item" key={index}>
+            <div className="box">
+              <a href={demo.thumbnailLink} target="_blank" rel="noopener noreferrer">
+                <div className="thumbnail" style={{ backgroundImage: `url(${demo.thumbnail})` }}></div>
+              </a>
+              <div className="bottom-content">
+                <div className="demo-name">{demo.name}</div>
+                <div className="icon-container">
+                  <a href={demo.playLink} target="_blank" rel="noopener noreferrer">
+                    <button className="icon play-button"></button>
+                  </a>
+                  <a href={demo.githubLink} target="_blank" rel="noopener noreferrer">
+                    <img src="https://cdn-icons-png.flaticon.com/512/25/25231.png" alt="GitHub Logo" className="icon github-icon" />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PageOther;


### PR DESCRIPTION
Adds an additional tab beside "BrowserDemo" called "Other" which opens up a separate page aggregating existing demos, videos, and repositories involving Particle WaaS- creating a natural location to view relevant demos, significantly reducing content fragmentation.

Adding new demos:
1. Fork `particle-web-demo`
2. Open `packages/web-demo/src/pages/other/index.tsx`
3. Add additional item within `demos` array
4. Open PR with changes